### PR TITLE
perf(catalog): weekly cache — zero Supabase queries and zero network on mobile

### DIFF
--- a/backend/api/src/__tests__/unit/racketController.test.ts
+++ b/backend/api/src/__tests__/unit/racketController.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../services/racketService', () => ({
     getBrands: vi.fn(),
     getStats: vi.fn(),
   },
+  secondsUntilNextSunday: vi.fn().mockReturnValue(604800),
 }));
 
 const mockRackets = [

--- a/backend/api/src/controllers/racketController.ts
+++ b/backend/api/src/controllers/racketController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { RacketService } from '../services/racketService';
+import { RacketService, secondsUntilNextSunday } from '../services/racketService';
 import { getPriceHistory } from '../services/priceHistoryService';
 import logger from '../config/logger';
 import { SearchFilters, SortOptions, ApiResponse, PaginatedResponse, Racket } from '../types';
@@ -38,7 +38,8 @@ export class RacketController {
         // ETag-based caching: compute version cheaply, skip full fetch on 304
         const etag = await RacketService.getCatalogETag();
         res.set('ETag', etag);
-        res.set('Cache-Control', 'public, max-age=0, must-revalidate');
+        const maxAge = secondsUntilNextSunday();
+        res.set('Cache-Control', `public, max-age=${maxAge}, stale-while-revalidate=86400`);
 
         if (req.headers['if-none-match'] === etag) {
           res.status(304).end();

--- a/backend/api/src/services/racketService.ts
+++ b/backend/api/src/services/racketService.ts
@@ -407,12 +407,40 @@ async function fetchRemainingRackets(initialData: any[], count: number): Promise
   return allData;
 }
 
+interface CatalogCache {
+  data: Racket[];
+  etag: string;
+  expiresAt: number;
+}
+
+let catalogCache: CatalogCache | null = null;
+
+/** Returns ms until next Sunday 00:00:00 local time. Min 1h to avoid edge cases. */
+function msUntilNextSunday(): number {
+  const now = new Date();
+  const daysUntilSunday = now.getDay() === 0 ? 7 : 7 - now.getDay();
+  const next = new Date(now);
+  next.setDate(now.getDate() + daysUntilSunday);
+  next.setHours(0, 0, 0, 0);
+  return Math.max(next.getTime() - now.getTime(), 60 * 60 * 1000);
+}
+
+/** Returns seconds until next Sunday 00:00:00, for use in Cache-Control max-age. */
+export function secondsUntilNextSunday(): number {
+  return Math.floor(msUntilNextSunday() / 1000);
+}
+
+function isCacheValid(): boolean {
+  return !!(catalogCache && Date.now() < catalogCache.expiresAt);
+}
+
 export class RacketService {
-  /**
-   * Obtiene todas las palas desde caché o base de datos
-   * Usa caché en RAM para servir respuestas rápidas si el catálogo no ha cambiado
-   */
   static async getAllRackets(): Promise<Racket[]> {
+    if (isCacheValid()) {
+      logger.info(`⚡ Catalog from RAM cache (${catalogCache!.data.length} rackets)`);
+      return catalogCache!.data;
+    }
+
     try {
       logger.info('🔄 Cargando catálogo desde Supabase...');
 
@@ -437,7 +465,20 @@ export class RacketService {
       }
 
       const processedData = processRacketData(allData);
-      return processedData.map(mapToFrontendFormat);
+      const rackets = processedData.map(mapToFrontendFormat);
+
+      const latestUpdate = allData.reduce(
+        (max: string, r: any) => (r.updated_at > max ? r.updated_at : max),
+        ''
+      );
+      const etag = `"${latestUpdate}_${allData.length}"`;
+      const expiresAt = Date.now() + msUntilNextSunday();
+
+      catalogCache = { data: rackets, etag, expiresAt };
+      const expiryDate = new Date(expiresAt).toISOString();
+      logger.info(`💾 Catalog cached in RAM (${rackets.length} rackets, expires ${expiryDate})`);
+
+      return rackets;
     } catch (error: unknown) {
       logger.error('Failed to connect to Supabase:', error);
       throw error;
@@ -445,11 +486,13 @@ export class RacketService {
   }
 
   /**
-   * Computes a lightweight ETag for the catalog.
-   * Used by the controller to return 304 when nothing changed.
-   * Single query: max(updated_at) + total count.
+   * Returns ETag from RAM cache if valid (~0ms); falls back to two lightweight Supabase queries.
    */
   static async getCatalogETag(): Promise<string> {
+    if (isCacheValid()) {
+      return catalogCache!.etag;
+    }
+
     try {
       const [{ data }, countResult] = await Promise.all([
         supabase

--- a/frontend/src/contexts/RacketsContext.tsx
+++ b/frontend/src/contexts/RacketsContext.tsx
@@ -69,6 +69,7 @@ export const RacketsProvider: React.FC<RacketsProviderProps> = ({
   const refreshRackets = useCallback(async (): Promise<void> => {
     localStorage.removeItem('smashly_catalog');
     localStorage.removeItem('smashly_catalog_etag');
+    localStorage.removeItem('smashly_catalog_expiry');
     await fetchRackets();
   }, [fetchRackets]);
 

--- a/frontend/src/services/racketService.ts
+++ b/frontend/src/services/racketService.ts
@@ -239,14 +239,26 @@ export class RacketService {
   }
 
   /**
-   * Obtiene todas las palas con caché ETag:
-   * - Envía If-None-Match con el ETag guardado
-   * - 304 → devuelve localStorage (sin descargar el catálogo)
-   * - 200 → guarda nuevo ETag + catálogo en localStorage, retorna
+   * Obtiene todas las palas con caché ETag + expiración semanal (domingos):
+   * - Si localStorage tiene datos válidos (no expirados) → envía If-None-Match
+   * - 304 → devuelve localStorage directamente (sin descargar el catálogo)
+   * - 200 → guarda nuevo ETag + catálogo + expiración en localStorage
+   * - Cache-Control max-age del servidor cubre la mayoría de visitas recurrentes sin red
    */
   static async getAllRacketsCached(): Promise<Racket[]> {
     const CACHE_KEY = 'smashly_catalog';
     const ETAG_KEY = 'smashly_catalog_etag';
+    const EXPIRY_KEY = 'smashly_catalog_expiry';
+
+    const storedExpiry = localStorage.getItem(EXPIRY_KEY);
+    const cacheExpired = storedExpiry ? Date.now() > parseInt(storedExpiry, 10) : true;
+
+    // Clear stale cache on Sunday expiry so next fetch gets fresh data
+    if (cacheExpired) {
+      localStorage.removeItem(CACHE_KEY);
+      localStorage.removeItem(ETAG_KEY);
+      localStorage.removeItem(EXPIRY_KEY);
+    }
 
     const storedETag = localStorage.getItem(ETAG_KEY);
     const storedData = localStorage.getItem(CACHE_KEY);
@@ -269,14 +281,22 @@ export class RacketService {
       const data = await handleApiResponse<Racket[]>(response);
       const newETag = response.headers.get('ETag') || '';
 
+      // Expiry = next Sunday 00:00:00
+      const now = new Date();
+      const daysUntilSunday = now.getDay() === 0 ? 7 : 7 - now.getDay();
+      const nextSunday = new Date(now);
+      nextSunday.setDate(now.getDate() + daysUntilSunday);
+      nextSunday.setHours(0, 0, 0, 0);
+
       try {
         localStorage.setItem(CACHE_KEY, JSON.stringify(data));
         if (newETag) localStorage.setItem(ETAG_KEY, newETag);
+        localStorage.setItem(EXPIRY_KEY, String(nextSunday.getTime()));
       } catch (e) {
         logger.warn('localStorage quota exceeded:', e);
       }
 
-      logger.log(`💾 Catálogo actualizado (${data.length} palas)`);
+      logger.log(`💾 Catálogo actualizado (${data.length} palas, expira ${nextSunday.toISOString()})`);
       return data;
     } catch (error: any) {
       // Fallback to stale localStorage data rather than failing completely


### PR DESCRIPTION
## Summary

- **Backend RAM cache**: catalog stored in memory until next Sunday midnight — subsequent requests served in ~0ms instead of 1-2s Supabase round-trip
- **Dynamic `Cache-Control`**: `max-age` set to seconds until next Sunday + `stale-while-revalidate=1d` — mobile browser serves catalog without any network request all week
- **Frontend localStorage expiry**: stores expiry timestamp (next Sunday 00:00) alongside ETag; stale cache cleared on load so Sunday fetch always gets fresh data

## What doesn't update mid-week (by design)
- "Palas más vistas" view counts — embedded in catalog data, will refresh on Sunday with the rest

## Test plan
- [ ] First visit (cold): catalog loads from Supabase, RAM cache populated
- [ ] Second visit same session: check logs show "⚡ Catalog from RAM cache"
- [ ] Check response headers: `Cache-Control` has `max-age` > 0 and `ETag` present
- [ ] Clear localStorage, reload: fetches fresh, stores new expiry key `smashly_catalog_expiry`
- [ ] Set `smashly_catalog_expiry` to past timestamp, reload: cache cleared, fresh fetch triggered
- [ ] Mobile DevTools Network tab: second visit shows "(disk cache)" or 304

🤖 Generated with [Claude Code](https://claude.com/claude-code)